### PR TITLE
fix :: StepHeader show logic

### DIFF
--- a/src/components/auth/authLayout/AuthStepComponentLayout/StepHeader.tsx
+++ b/src/components/auth/authLayout/AuthStepComponentLayout/StepHeader.tsx
@@ -8,9 +8,10 @@ interface SignupHeaderProps {
   step?: number,
   maxStep?: number,
   onPrev: () => void,
+  isShow?: boolean,
 }
 
-export default function StepHeader({ step = 0, maxStep = 3, onPrev }: SignupHeaderProps) {
+export default function StepHeader({ step = 0, maxStep = 3, onPrev, isShow = true }: SignupHeaderProps) {
   const navigation = useNavigation<AuthNav>();
   const nowStep = Math.floor(step);
   
@@ -20,7 +21,7 @@ export default function StepHeader({ step = 0, maxStep = 3, onPrev }: SignupHead
         <Image source={btn_previous_default} style={{ width: 24, height: 24}} />
       </Pressable>
       {/* TODO: 최대 step 지정 후 isShowStep 이런 식으로 step 보여주기 여부로 변경 필요함 */}
-      {step !== 0 && step < (maxStep + 1) && <Typography children={`${nowStep} / ${maxStep}`} font='medium16' color='defaultBlack' />}
+      {isShow && step !== 0 && step < (maxStep + 1) && <Typography children={`${nowStep} / ${maxStep}`} font='medium16' color='defaultBlack' />}
     </View>
   )
 }

--- a/src/screens/auth/Id/FindIdScreen.tsx
+++ b/src/screens/auth/Id/FindIdScreen.tsx
@@ -20,7 +20,7 @@ export default function FindIdScreen() {
     <KeyboardDismiss>
       <AuthStepLayout>
         <>  
-          <StepHeader onPrev={handlePrev} />
+          <StepHeader onPrev={handlePrev} step={step} isShow={false} />
           <ActionLayout label={labels[step - 1]} onNext={handleNext} isValid={stepValid} step={step}>
             <StepContent step={step} form={form} setForm={setForm} updateStepValid={updateStepValid} />
           </ActionLayout>

--- a/src/screens/auth/password/FindPasswordScreen.tsx
+++ b/src/screens/auth/password/FindPasswordScreen.tsx
@@ -20,7 +20,7 @@ export default function FindPasswordScreen() {
     <KeyboardDismiss>
       <AuthStepLayout>
         <>  
-          <StepHeader onPrev={handlePrev} />
+          <StepHeader onPrev={handlePrev} step={step} isShow={false} />
           <ActionLayout label={labels[step - 1]} onNext={handleNext} isValid={stepValid} step={step}>
             <StepContent step={step} form={form} setForm={setForm} updateStepValid={updateStepValid} />
           </ActionLayout>


### PR DESCRIPTION
-기존에는 step을 넘기지 않아 현재 step이 1과 같은지 비교할 수 없어 goBack()이 제대로 작동하지 않았다. 그렇기 때문에 step을 넘기고 오른쪽 위 스탭 표시를 다른 상태를 이용하도록 개발
-StepHeader의 오른 쪽 위 step 표시를 isShow라는 prop을 하나 더 받아 선택 사항으로 두도록 개발

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 인증 화면의 단계 표시기를 선택적으로 표시하거나 숨길 수 있는 기능이 추가되었습니다.
* 아이디 찾기 및 비밀번호 찾기 화면에서 단계 표시기가 숨겨지도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->